### PR TITLE
Added title tag

### DIFF
--- a/newtab.html
+++ b/newtab.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="utf-8">
+    <title>FRC New Tab</title>
     <link rel="stylesheet" href="css/newtab.css">
 </head>
 


### PR DESCRIPTION
Currently, the title of the tab displays as "chrome://newtab" which is a little suboptimal. I changed the title to "FRC New Tab".